### PR TITLE
support use array to assign generator chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,33 @@
     assert(tokenChars.length < 256);
   }
 
+  function getChars (chars) {
+    var result;
+    switch( chars ) {
+      case 'default':
+        result = alphaNumeric;
+        break;
+      case 'a-z':
+      case 'alpha':
+        result = alphaLower;
+        break;
+      case 'A-Z':
+      case 'ALPHA':
+        result = alphaUpper;
+        break;
+      case '0-9':
+      case 'numeric':
+        result = numeric;
+        break;
+      case 'base32':
+        result = alphaUpper + "234567";
+        break;
+      default:
+        // use the characters as is
+    }
+    return result;
+  }
+
   function buildGenerator(options) {
     assert(!options || typeof(options) == 'object');
     options = options || {};
@@ -29,27 +56,14 @@
     options.source = options.source || defaults.source;
 
     // Allowed characters
-    switch( options.chars ) {
-      case 'default':
-        options.chars = alphaNumeric;
-        break;
-      case 'a-z':
-      case 'alpha':
-        options.chars = alphaLower;
-        break;
-      case 'A-Z':
-      case 'ALPHA':
-        options.chars = alphaUpper;
-        break;
-      case '0-9':
-      case 'numeric':
-        options.chars = numeric;
-        break;
-      case 'base32':
-        options.chars = alphaUpper + "234567";
-        break;
-      default:
-        // use the characters as is
+    if (Array.isArray(options.chars)) {
+      var charsSet = '';
+      options.chars.forEach(function(item) {
+        charsSet += getChars(item);
+      });
+      options.chars = charsSet;
+    } else {
+      options.chars = getChars(options.chars);
     }
     validateTokenChars(options.chars);
 

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,8 @@ var tokenCharsToTest = [
   {chars: 'alpha', regex: /^[a-z]{16}$/ },
   {chars: 'ALPHA', regex: /^[A-Z]{16}$/ },
   {chars: 'numeric', regex: /^[0-9]{16}$/ },
+  {chars: ['ALPHA', 'numeric'], regex: /^[a-z0-9]{16}$/},
+  {chars: ['alpha', 'ALPHA', 'numeric'], regex: /^[a-zA-Z0-9]{16}$/},
 ];
 
 _.each(randSourceToTest, function(randSourceTest) {


### PR DESCRIPTION
Right now did not support assign multiple chars in generator,
maybe this way would be more flexible?
e.g.
```
var randtoken = require('rand-token').generator({
  chars: ['A-Z', '0-9'],
  source: 'default'
});
```