### PR TITLE
Fix exception in crytpo.randomBytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@
     switch( options.source ) {
       case 'default':
         options.source = function(size, cb) {
-          return cryptoRandomBytes(size, !cb ? null : function (buf){
+          return cryptoRandomBytes(size, !cb ? undefined : function (buf){
             return cb(null, buf);
           });
         };


### PR DESCRIPTION
`null` is not an accepted value for a `sync` callback. The value must either be `undefined` or a function.